### PR TITLE
test page 기본 틀 개발 + 공용 component 개발

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.7.1",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "prettier": "^2.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.4.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "save-dev": "^0.0.1-security",
@@ -14548,6 +14549,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -27707,6 +27716,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.4.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "save-dev": "^0.0.1-security",

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -1,0 +1,52 @@
+import styled, { css } from 'styled-components';
+
+const Button = styled.button`
+  width: ${(props) => props.width || 100}%;
+  height: ${(props) => props.height || 100}%;
+  background-color: ${(props) => props.backgroundColor || 'white'};
+  font-size: ${(props) => props.fontSize || 25}px;
+  font-weight: ${(props) => props.fontWeight || 400};
+  color: ${(props) => props.fontColor || 'black'};
+  border-radius: ${(props) => props.radius || 25}px;
+  margin-top: ${(props) => props.marginTop || 0}px;
+  margin-bottom: ${(props) => props.marginBottom || 0}px;
+  padding-left: ${(props) => props.paddingLeft || 0}px;
+  padding-right: ${(props) => props.paddingRight || 0}px;
+  padding-top: ${(props) => props.paddingTop || 0}px;
+  padding-bottom: ${(props) => props.paddingBottom || 0}px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: none;
+  font-family: 'Noto Sans KR', sans-serif;
+  word-break: keep-all;
+  transition: 0.3s;
+
+  &:focus {
+    background-color: ${(props) => props.focusBackgroundColor || 'black'};
+    color: ${(props) => props.focusFontColor || 'white'};
+    transition: 0.3s;
+  }
+
+  ${(props) =>
+    props.shadow &&
+    css`
+      box-shadow: 0 0 30px 1px rgba(0, 0, 0, 0.1);
+    `}
+
+  ${(props) =>
+    props.otherFont &&
+    css`
+      font-family: 'Frank Ruhl Libre', serif;
+    `}
+
+    ${(props) =>
+    props.clicked &&
+    css`
+      background-color: ${(props) =>
+        props.isClicked === 1 ? 'black' : 'white'};
+      color: ${(props) => (props.isClicked === 1 ? 'white' : 'black')};
+    `}
+`;
+
+export default Button;

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: content-box;
+`;
+
+const Title = styled.div`
+  width: 85%;
+  margin-top: 60px;
+  font-size: 25px;
+  font-weight: 900;
+  font-family: 'Frank Ruhl Libre', serif;
+  text-align: left;
+  color: black;
+`;
+
+const Underline = styled.hr`
+  width: 85%;
+  margin-top: 15px;
+`;
+
+const Header = () => {
+  return (
+    <Wrapper>
+      <Title>Scent Test</Title>
+      <Underline />
+    </Wrapper>
+  );
+};
+
+export default Header;

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -27,7 +27,7 @@ const Underline = styled.hr`
 const Header = () => {
   return (
     <Wrapper>
-      <Title>Scent Test</Title>
+      <Title>Scent MBTI</Title>
       <Underline />
     </Wrapper>
   );

--- a/src/components/NavigationBar/index.jsx
+++ b/src/components/NavigationBar/index.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  MdHome,
+  MdScience,
+  MdPalette,
+  MdSettings,
+  MdEmojiEmotions,
+} from 'react-icons/md';
+
+const Wrapper = styled.div`
+  width: 100vw;
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const NavigationBox = styled.div`
+  width: 90%;
+  height: 60px;
+  margin-bottom: 30px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-evenly;
+  background-color: white;
+  border-radius: 30px;
+  box-shadow: 0 0 30px 1px rgba(0, 0, 0, 0.1);
+`;
+
+const NavigationButton = styled.button`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: none;
+  border: none;
+  transition: 0.3s;
+  &:hover {
+    padding-bottom: 7px;
+    transition: 0.3s;
+  }
+  &:focus {
+    padding-bottom: 7px;
+    transition: 0.3s;
+  }
+`;
+
+const NavigationBar = () => {
+  return (
+    <Wrapper>
+      <NavigationBox>
+        <NavigationButton type="button" value="home">
+          <MdHome size="28px" />
+        </NavigationButton>
+        <NavigationButton type="button" value="review">
+          <MdScience size="28px" />
+        </NavigationButton>
+        <NavigationButton type="button" value="test">
+          <MdPalette size="28px" />
+        </NavigationButton>
+        <NavigationButton type="button" value="setting">
+          <MdSettings size="28px" />
+        </NavigationButton>
+        <NavigationButton type="button" value="myPage">
+          <MdEmojiEmotions size="28px" />
+        </NavigationButton>
+      </NavigationBox>
+    </Wrapper>
+  );
+};
+
+export default NavigationBar;

--- a/src/components/NavigationBar/index.jsx
+++ b/src/components/NavigationBar/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import {
-  MdHome,
-  MdScience,
-  MdPalette,
-  MdSettings,
-  MdEmojiEmotions,
+  MdOutlineHome,
+  MdOutlineBrush,
+  MdOutlineScience,
+  MdOutlinePalette,
+  MdOutlineEmojiEmotions,
 } from 'react-icons/md';
 
 const Wrapper = styled.div`
@@ -52,19 +52,19 @@ const NavigationBar = () => {
     <Wrapper>
       <NavigationBox>
         <NavigationButton type="button" value="home">
-          <MdHome size="28px" />
-        </NavigationButton>
-        <NavigationButton type="button" value="review">
-          <MdScience size="28px" />
+          <MdOutlineHome size="28px" />
         </NavigationButton>
         <NavigationButton type="button" value="test">
-          <MdPalette size="28px" />
+          <MdOutlineBrush size="28px" />
+        </NavigationButton>
+        <NavigationButton type="button" value="palette">
+          <MdOutlinePalette size="28px" />
         </NavigationButton>
         <NavigationButton type="button" value="setting">
-          <MdSettings size="28px" />
+          <MdOutlineScience size="28px" />
         </NavigationButton>
         <NavigationButton type="button" value="myPage">
-          <MdEmojiEmotions size="28px" />
+          <MdOutlineEmojiEmotions size="28px" />
         </NavigationButton>
       </NavigationBox>
     </Wrapper>

--- a/src/components/ProgressBar/index.jsx
+++ b/src/components/ProgressBar/index.jsx
@@ -17,12 +17,13 @@ const Bar = styled.div`
   transition: width 1s;
   border-radius: 3px;
   background-color: black;
+  overflow: hidden;
 `;
 
-const ProgressBar = () => {
+const ProgressBar = (width) => {
   return (
     <BarContainer>
-      <Bar />
+      <Bar width={width.width} />
     </BarContainer>
   );
 };

--- a/src/components/ProgressBar/index.jsx
+++ b/src/components/ProgressBar/index.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const BarContainer = styled.div`
+  width: 75%;
+  height: 5px;
+  display: flex;
+  align-items: center;
+  border-radius: 3px;
+  background-color: rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 30px 1px rgba(0, 0, 0, 0.1);
+`;
+
+const Bar = styled.div`
+  width: ${(props) => props.width || 0}%;
+  height: 100%;
+  transition: width 1s;
+  border-radius: 3px;
+  background-color: black;
+`;
+
+const ProgressBar = () => {
+  return (
+    <BarContainer>
+      <Bar />
+    </BarContainer>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/TestForms/index.jsx
+++ b/src/components/TestForms/index.jsx
@@ -1,31 +1,619 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useState } from 'react';
+import styled, { keyframes } from 'styled-components';
+import Button from 'components/Button';
+
+const formFadeIn = keyframes`
+  100% {
+    opacity: 1
+  }
+`;
 
 const Wrapper = styled.div`
   width: 100vw;
   height: auto;
-  display: flex;
+  display: ${(props) => (props.visible ? 'flex' : 'none')};
   flex-direction: column;
   align-items: center;
   box-sizing: content-box;
+  opacity: 0;
+  animation-name: ${(props) => (props.visible ? formFadeIn : '')};
+  animation-duration: 1s;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
 `;
 
 const TestTitle = styled.div`
-  width: 70%;
-  padding-top: 80px;
-  padding-left: 30px;
-  padding-right: 30px;
+  width: 80%;
+  padding-top: ${(props) => props.paddingTop || 80}px;
   font-size: 25px;
-  font-weight: 800;
+  font-weight: 900;
   text-align: center;
+  line-height: 1.4;
+  word-break: keep-all;
   color: black;
 `;
 
-const TestForms = () => {
+const TestForms = (step) => {
+  const stepValue = step.step;
+  const [test1, setTest1] = useState({ a: 0, b: 0 });
+  const [test2, setTest2] = useState({ a: 0, b: 0, c: 0 });
+  const [test3, setTest3] = useState({ a: 0, b: 0 });
+  const [test4, setTest4] = useState({ a: 0, b: 0, c: 0 });
+  const [test5, setTest5] = useState({ a: 0, b: 0, c: 0 });
+  const [test6, setTest6] = useState({ a: 0, b: 0 });
+  const [test7, setTest7] = useState({ a: 0, b: 0, c: 0, d: 0 });
+
+  const buttonClick1 = (e) => {
+    if (e.target.value === 'test1A') {
+      setTest1({ a: 1, b: 0 });
+    }
+    if (e.target.value === 'test1B') {
+      setTest1({ a: 0, b: 1 });
+    }
+  };
+
+  const buttonClick2 = (e) => {
+    if (e.target.value === 'test2A') {
+      setTest2({ a: 1, b: 0, c: 0 });
+    }
+    if (e.target.value === 'test2B') {
+      setTest2({ a: 0, b: 1, c: 0 });
+    }
+    if (e.target.value === 'test2C') {
+      setTest2({ a: 0, b: 0, c: 1 });
+    }
+  };
+
+  const buttonClick3 = (e) => {
+    if (e.target.value === 'test3A') {
+      setTest3({ a: 1, b: 0 });
+    }
+    if (e.target.value === 'test3B') {
+      setTest3({ a: 0, b: 1 });
+    }
+  };
+
+  const buttonClick4 = (e) => {
+    if (e.target.value === 'test4A') {
+      setTest4({ a: 1, b: 0, c: 0 });
+    }
+    if (e.target.value === 'test4B') {
+      setTest4({ a: 0, b: 1, c: 0 });
+    }
+    if (e.target.value === 'test4C') {
+      setTest4({ a: 0, b: 0, c: 1 });
+    }
+  };
+
+  const buttonClick5 = (e) => {
+    if (e.target.value === 'test5A') {
+      setTest5({ a: 1, b: 0, c: 0 });
+    }
+    if (e.target.value === 'test5B') {
+      setTest5({ a: 0, b: 1, c: 0 });
+    }
+    if (e.target.value === 'test5C') {
+      setTest5({ a: 0, b: 0, c: 1 });
+    }
+  };
+
+  const buttonClick6 = (e) => {
+    if (e.target.value === 'test6A') {
+      setTest6({ a: 1, b: 0 });
+    }
+    if (e.target.value === 'test6B') {
+      setTest6({ a: 0, b: 1 });
+    }
+  };
+
+  const buttonClick7 = (e) => {
+    if (e.target.value === 'test7A') {
+      setTest7({ a: 1, b: 0, c: 0, d: 0 });
+    }
+    if (e.target.value === 'test7B') {
+      setTest7({ a: 0, b: 1, c: 0, d: 0 });
+    }
+    if (e.target.value === 'test7C') {
+      setTest7({ a: 0, b: 0, c: 1, d: 0 });
+    }
+    if (e.target.value === 'test7D') {
+      setTest7({ a: 0, b: 0, c: 0, d: 1 });
+    }
+
+    calculateResult();
+  };
+
+  let colorScore = {
+    redScore: 0,
+    yellowScore: 0,
+    greenScore: 0,
+    blueScore: 0,
+    blackScore: 0,
+    whiteScore: 0,
+    purpleScore: 0,
+  };
+
+  const [resultColor, setResultColor] = useState('');
+
+  const calculateResult = () => {
+    test1Result();
+    test2Result();
+    test3Result();
+    test4Result();
+    test5Result();
+    test7Result();
+
+    console.log(colorScore);
+    setResultColor('blue');
+  };
+
+  const test1Result = () => {
+    if (test1.a === 1) {
+      colorScore.blueScore++;
+      colorScore.blackScore++;
+      colorScore.purpleScore++;
+    }
+    if (test1.b === 1) {
+      colorScore.redScore++;
+      colorScore.yellowScore++;
+      colorScore.greenScore++;
+      colorScore.whiteScore++;
+    }
+  };
+
+  const test2Result = () => {
+    if (test2.a === 1) {
+      colorScore.blueScore++;
+      colorScore.greenScore++;
+    }
+    if (test2.b === 1) {
+      colorScore.blackScore++;
+      colorScore.whiteScore++;
+    }
+    if (test2.c === 1) {
+      colorScore.redScore++;
+      colorScore.yellowScore++;
+      colorScore.purpleScore++;
+    }
+  };
+
+  const test3Result = () => {
+    if (test3.a === 1) {
+      colorScore.blueScore++;
+      colorScore.redScore++;
+      colorScore.yellowScore++;
+      colorScore.whiteScore++;
+    }
+    if (test3.b === 1) {
+      colorScore.blackScore++;
+      colorScore.purpleScore++;
+      colorScore.greenScore++;
+    }
+  };
+
+  const test4Result = () => {
+    if (test4.a === 1) {
+      colorScore.whiteScore++;
+      colorScore.yellowScore++;
+      colorScore.greenScore++;
+    }
+    if (test4.b === 1) {
+      colorScore.redScore++;
+      colorScore.purpleScore++;
+    }
+    if (test4.c === 1) {
+      colorScore.blueScore++;
+      colorScore.blackScore++;
+    }
+  };
+
+  const test5Result = () => {
+    if (test5.a === 1) {
+      colorScore.redScore++;
+      colorScore.yellowScore++;
+      colorScore.greenScore++;
+      colorScore.whiteScore++;
+      colorScore.purpleScore++;
+    }
+    if (test5.b === 1) {
+      colorScore.greenScore++;
+      colorScore.blueScore++;
+      colorScore.blackScore++;
+      colorScore.whiteScore++;
+      colorScore.purpleScore++;
+    }
+    if (test5.c === 1) {
+      colorScore.redScore++;
+      colorScore.yellowScore++;
+      colorScore.greenScore++;
+      colorScore.blueScore++;
+      colorScore.blackScore++;
+      colorScore.whiteScore++;
+      colorScore.purpleScore++;
+    }
+  };
+
+  const test7Result = () => {
+    if (test7.a === 1) {
+      colorScore.redScore++;
+      colorScore.yellowScore++;
+      calculateResult();
+    }
+    if (test7.b === 1) {
+      colorScore.greenScore++;
+      calculateResult();
+    }
+    if (test7.c === 1) {
+      colorScore.blueScore++;
+      colorScore.whiteScore++;
+      calculateResult();
+    }
+    if (test7.d === 1) {
+      colorScore.blackScore++;
+      colorScore.purpleScore++;
+      calculateResult();
+    }
+  };
+
   return (
     <>
-      <Wrapper>
-        <TestTitle>안녕?</TestTitle>
+      <Wrapper visible={stepValue === 1}>
+        <TestTitle>
+          어느날 눈을 떠보니
+          <br /> 아기사자가 된 당신! 🦁
+          <br /> 이때 당신의 반응은?
+        </TestTitle>
+        <Button
+          shadow
+          clicked
+          isClicked={test1.a}
+          width="85"
+          marginTop="70"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test1A"
+          onClick={buttonClick1}
+        >
+          난 언제나 이런 새 삶을 원했어!
+          <br /> 아기사자가 되어 세상을 헤집어보자!
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test1.b}
+          width="85"
+          marginTop="30"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test1B"
+          onClick={buttonClick1}
+        >
+          안돼… 이런 익숙지 않은 몸…
+          <br /> 잡아먹힐지도 몰라!
+        </Button>
+      </Wrapper>
+
+      <Wrapper visible={stepValue === 2}>
+        <TestTitle>
+          이… 이곳은 😱
+          <br /> 우리집 방구석이 아니다!
+          <br /> 여기가 어디지?
+        </TestTitle>
+        <Button
+          shadow
+          clicked
+          isClicked={test2.a}
+          width="85"
+          marginTop="50"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test2A"
+          onClick={buttonClick2}
+        >
+          고요한 바람소리만 귓가를 맴돈다.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test2.b}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test2B"
+          onClick={buttonClick2}
+        >
+          빵빵거리며 지나가는 자동차와
+          <br /> 어디론가 바삐 걸어가는 사람들.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test2.c}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test2C"
+          onClick={buttonClick2}
+        >
+          저 멀리 동산을 가득 채우는
+          <br /> 알록달록한 과일과 꽃이 보인다.
+        </Button>
+      </Wrapper>
+
+      <Wrapper visible={stepValue === 3}>
+        <TestTitle>
+          가만히 서있을 수는
+          <br /> 없어! 일단 앞으로
+          <br /> 걸어나가려 한다.🔥
+        </TestTitle>
+        <Button
+          shadow
+          clicked
+          isClicked={test3.a}
+          width="85"
+          marginTop="70"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test3A"
+          onClick={buttonClick3}
+        >
+          밝은 곳으로 걸어가자.
+          <br /> 누군가 도와줄거야.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test3.b}
+          width="85"
+          marginTop="30"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test3B"
+          onClick={buttonClick3}
+        >
+          어두운 곳으로 걸어가야해.
+          <br /> 잡혀갈지도 몰라.
+        </Button>
+      </Wrapper>
+
+      <Wrapper visible={stepValue === 4}>
+        <TestTitle paddingTop={40}>
+          하염없이 걷다보니
+          <br /> 배가 고프다. 🤤
+          <br /> 이 때 누군가가 당신에게
+          <br /> 잘 차려진 식사를 대접한다.
+        </TestTitle>
+        <Button
+          shadow
+          clicked
+          isClicked={test4.a}
+          width="85"
+          marginTop="50"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test4A"
+          onClick={buttonClick4}
+        >
+          하얀 식탁보 위에 가지런히 놓인 빵과 꿀.
+          <br /> 진한 녹차도 준비되어 있다.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test4.b}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test4B"
+          onClick={buttonClick4}
+        >
+          알록달록 식탁보 위의 딸기케이크.
+          <br /> 음료는… 프룬주스?
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test4.c}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test4C"
+          onClick={buttonClick4}
+        >
+          아이스박스 위에 얼음으로 가득 찬 바스켓.
+          <br /> 든든한 볶음밥과 시원한 콜라가 놓여있다.
+        </Button>
+      </Wrapper>
+
+      <Wrapper visible={stepValue === 5}>
+        <TestTitle paddingTop={30}>
+          정신없이 허기진 배를 채우고
+          <br /> 의문의 조력자에게
+          <br /> 감사인사를 건넨다. 😀
+          <br /> 그런데 이 사람 이상한 모자를 쓰고, 포대자루도 들고 있다.
+        </TestTitle>
+        <Button
+          shadow
+          clicked
+          isClicked={test5.a}
+          width="85"
+          marginTop="50"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test5A"
+          onClick={buttonClick5}
+        >
+          삐에로 모자다.
+          <br /> 코를 찌르는 사자우리 냄새가 난다.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test5.b}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test5B"
+          onClick={buttonClick5}
+        >
+          양봉업자 모자다.
+          <br /> 과한 바닐라향에 속이 더부룩해진다.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test5.c}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test5C"
+          onClick={buttonClick5}
+        >
+          몰라 그냥 도망간다.
+        </Button>
+      </Wrapper>
+
+      <Wrapper visible={stepValue === 6}>
+        <TestTitle>
+          얼마나 도망쳤을까…
+          <br /> 풍경이 바뀌어 주변을 둘러보니 온통 하얀색에 일곱개의 문이
+          덩그러니 놓여있다. 🚪
+        </TestTitle>
+        <Button
+          shadow
+          clicked
+          isClicked={test6.a}
+          width="85"
+          marginTop="70"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test6A"
+          onClick={buttonClick6}
+        >
+          궁금해. 어서 열어봐야겠다.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test6.b}
+          width="85"
+          marginTop="30"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test6B"
+          onClick={buttonClick6}
+        >
+          또 무슨 일이 기다리고 있을 지 몰라.
+          <br /> 경계하며 조심스럽게 문을 연다.
+        </Button>
+      </Wrapper>
+
+      <Wrapper visible={stepValue === 7}>
+        <TestTitle paddingTop={50}>
+          문고리가 굳게 잠겨있다. 🗝️
+          <br /> 열쇠는… 내 주머니 안에 있다고?
+        </TestTitle>
+        <Button
+          shadow
+          clicked
+          isClicked={test7.a}
+          width="85"
+          marginTop="50"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test7A"
+          onClick={buttonClick7}
+        >
+          설탕으로 만든 열쇠를 꺼낸다.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test7.b}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test7B"
+          onClick={buttonClick7}
+        >
+          나무로 된 열쇠를 꺼낸다.
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test7.c}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test7C"
+          onClick={buttonClick7}
+        >
+          하얀 보자기에 쌓여있는
+          <br /> 도자기 열쇠를 꺼낸다
+        </Button>
+        <Button
+          shadow
+          clicked
+          isClicked={test7.d}
+          width="85"
+          marginTop="15"
+          paddingTop="30"
+          paddingBottom="30"
+          fontSize="18"
+          fontWeight="800"
+          value="test7D"
+          onClick={buttonClick7}
+        >
+          철문에 어울리는 열쇠를 꺼낸다.
+        </Button>
+      </Wrapper>
+
+      <Wrapper visible={stepValue === 8}>
+        <TestTitle paddingTop={150}>{resultColor}</TestTitle>
       </Wrapper>
     </>
   );

--- a/src/components/TestForms/index.jsx
+++ b/src/components/TestForms/index.jsx
@@ -3,16 +3,30 @@ import styled from 'styled-components';
 
 const Wrapper = styled.div`
   width: 100vw;
+  height: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   box-sizing: content-box;
 `;
 
+const TestTitle = styled.div`
+  width: 70%;
+  padding-top: 80px;
+  padding-left: 30px;
+  padding-right: 30px;
+  font-size: 25px;
+  font-weight: 800;
+  text-align: center;
+  color: black;
+`;
+
 const TestForms = () => {
   return (
     <>
-      <Wrapper></Wrapper>
+      <Wrapper>
+        <TestTitle>안녕?</TestTitle>
+      </Wrapper>
     </>
   );
 };

--- a/src/components/TestForms/index.jsx
+++ b/src/components/TestForms/index.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: content-box;
+`;
+
+const TestForms = () => {
+  return (
+    <>
+      <Wrapper></Wrapper>
+    </>
+  );
+};
+
+export default TestForms;

--- a/src/pages/ScentTest/index.jsx
+++ b/src/pages/ScentTest/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { MdArrowBack, MdArrowForward } from 'react-icons/md';
 import Header from 'components/Header';
+import TestForms from 'components/TestForms';
 import ProgressBar from 'components/ProgressBar';
 import NavigationBar from 'components/NavigationBar';
 
@@ -35,6 +36,7 @@ const ScentTest = () => {
   return (
     <>
       <Header />
+      <TestForms />
       <Wrapper>
         <BarBox>
           <BarButton>

--- a/src/pages/ScentTest/index.jsx
+++ b/src/pages/ScentTest/index.jsx
@@ -1,10 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import { MdArrowBack, MdArrowForward } from 'react-icons/md';
 import Header from 'components/Header';
+import ProgressBar from 'components/ProgressBar';
 import NavigationBar from 'components/NavigationBar';
+
+const Wrapper = styled.div`
+  width: 100vw;
+  position: fixed;
+  bottom: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const BarBox = styled.div`
+  width: 90%;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const BarButton = styled.button`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: none;
+  border: none;
+`;
 
 const ScentTest = () => {
   return (
     <>
       <Header />
+      <Wrapper>
+        <BarBox>
+          <BarButton>
+            <MdArrowBack size="28px" />
+          </BarButton>
+          <ProgressBar />
+          <BarButton>
+            <MdArrowForward size="28px" />
+          </BarButton>
+        </BarBox>
+      </Wrapper>
       <NavigationBar />
     </>
   );

--- a/src/pages/ScentTest/index.jsx
+++ b/src/pages/ScentTest/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { MdArrowBack, MdArrowForward } from 'react-icons/md';
 import Header from 'components/Header';
@@ -33,17 +33,27 @@ const BarButton = styled.button`
 `;
 
 const ScentTest = () => {
+  const [step, setStep] = useState(1);
+
+  const nextStep = () => {
+    setStep(step + 1);
+  };
+
+  const beforeStep = () => {
+    setStep(step - 1);
+  };
+
   return (
     <>
       <Header />
-      <TestForms />
+      <TestForms step={step} />
       <Wrapper>
         <BarBox>
-          <BarButton>
+          <BarButton onClick={beforeStep}>
             <MdArrowBack size="28px" />
           </BarButton>
-          <ProgressBar />
-          <BarButton>
+          <ProgressBar width={(step / 7) * 100} />
+          <BarButton onClick={nextStep}>
             <MdArrowForward size="28px" />
           </BarButton>
         </BarBox>

--- a/src/pages/ScentTest/index.jsx
+++ b/src/pages/ScentTest/index.jsx
@@ -1,0 +1,13 @@
+import Header from 'components/Header';
+import NavigationBar from 'components/NavigationBar';
+
+const ScentTest = () => {
+  return (
+    <>
+      <Header />
+      <NavigationBar />
+    </>
+  );
+};
+
+export default ScentTest;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Main from '../pages/Main';
+import ScentTest from 'pages/ScentTest';
 
 // 라우트명은 kebab-case 로 작성합니다
 
@@ -7,6 +8,7 @@ const Router = () => (
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<Main />} />
+      <Route path="/home/scent-test" element={<ScentTest />} />
     </Routes>
   </BrowserRouter>
 );

--- a/src/styles/GlobalStyles.jsx
+++ b/src/styles/GlobalStyles.jsx
@@ -4,19 +4,22 @@ import './font.css';
 
 const GlobalStyle = createGlobalStyle`
     ${reset};
-    
+
     body{
+        width: 100vw;
+        height: 100vh;
         display: flex;
         flex-direction: column;
         align-items: center;
         background-color: #FFFAF5;
-        font-family:'-apple-system', 'BlinkMacSystemFont', 
-        'Apple SD Gothic Neo','Inter', 'Spoqa Han Sans', 
-        'Segoe UI', Sans-Serif, 'Apple Color Emoji', 'Segoe UI Emoji', 
-        'Segoe UI Symbol';
+        font-family: 'Noto Sans KR', sans-serif;
         -ms-overflow-style: none; /* IE and Edge */
         scrollbar-width: none; /* Firefox */
     };
+
+    &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export default GlobalStyle;

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,2 +1,2 @@
-@import url('https://rsms.me/inter/inter.css');
-@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSans-kr.css);
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre&display=swap');


### PR DESCRIPTION
## PR 내용
## 공용 component 기본 틀 작성

### navigation bar, header component
- navigation bar, header component를 작성하였습니다.
- navigation bar의 경우 icon만 들어있는 상태로 따로 다른 페이지로 이동이 가능하게끔 처리하지는 않았습니다.
- header의 경우 props가 오류로 인해 받아지지 않아 현재는 Scent MBTI로 고정되어 있습니다. (현재 작성 코드 기준으로는 이상이 없습니다.) 이후에 페이지별로 header title을 다르게 지정할 수 있도록 수정이 필요합니다.

### button
- button의 경우 width, height, padding, margin, background color, shadow 유무 등을 props로 변경할 수 있도록 하였습니다. (자세한 사항은 코드 확인 요망)

## test page 기본 틀 작성
- test page를 위해 progress bar component와 testform component를 작성하였습니다.
- testform의 경우 step을 testpage로부터 갱신받아 각 경우 다른 form을 보여주도록 하였습니다.
- test 결과의 모호함이 발견되어 결과는 따로 출력하지 않았습니다. (임시로 8번째 페이지에 blue 출력. 이후에 max값을 구하여 연결하면 끝)
- 이후에 step이 일정 범위를 벗어나지 못하게 추가 작성이 필요할 것으로 예상됩니다.

## install prop-types
- eslint에서는 prop의 type을 명시하도록 제한하므로 이후에 사용을 위해서 prop-types를 install 하였습니다.

## 완성품 사진
![image](https://user-images.githubusercontent.com/79556112/180175579-c43e91bb-3bea-45e7-8670-12b60217deaf.png)
