### PR TITLE
Header Component 수정 + 관련 Page 수정

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 const Wrapper = styled.div`
   width: 100vw;
@@ -24,13 +25,17 @@ const Underline = styled.hr`
   margin-top: 15px;
 `;
 
-const Header = () => {
+const Header = (title) => {
   return (
     <Wrapper>
-      <Title>Scent MBTI</Title>
+      <Title>{title.title}</Title>
       <Underline />
     </Wrapper>
   );
+};
+
+Header.title = {
+  title: PropTypes.node.isRequired,
 };
 
 export default Header;

--- a/src/pages/ScentTest/index.jsx
+++ b/src/pages/ScentTest/index.jsx
@@ -45,7 +45,7 @@ const ScentTest = () => {
 
   return (
     <>
-      <Header />
+      <Header title="Per/scent" />
       <TestForms step={step} />
       <Wrapper>
         <BarBox>


### PR DESCRIPTION
## PR 내용
header component에서 props로 title을 전달받도록 수정하였습니다. propTypes를 지정하여 eslint 오류를 해결하였으며, header가 들어간 test page의 header에 title props를 추가하여 "Per/scent"로 title이 변경되도록 수정하였습니다.

propTypes 관련된 부분은 하단 링크 참고하시면 좋을 것 같습니다!!

https://haerim95.tistory.com/41

## 완성품 사진
![image](https://user-images.githubusercontent.com/79556112/180607333-50231690-078c-4bb3-891a-db26037947cd.png)

## 링크
Trello: https://trello.com/b/1CvPRp9B/%EB%A9%8B%EC%9F%81%EC%9D%B4%EC%82%AC%EC%B0%A8%EB%9F%AC%EB%9F%BC-%EC%9D%B8%ED%95%98%EB%8C%80%ED%95%B4%EC%BB%A4%ED%86%A4