### PR TITLE
Other Color Page 추가 + 페이지 전환 애니메이션 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dom-to-image": "^2.6.0",
         "eslint-plugin-prettier": "^4.2.1",
         "file-saver": "^2.0.5",
+        "framer-motion": "^6.5.1",
         "prettier": "^2.7.1",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -2957,6 +2958,64 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@motionone/animation": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.13.1.tgz",
+      "integrity": "sha512-dxQ+1wWxL6iFHDy1uv6hhcPjIdOg36eDT56jN4LI7Z5HZRyLpq8x1t7JFQclo/IEIb+6Bk4atmyinGFdXVECuA==",
+      "dependencies": {
+        "@motionone/easing": "^10.13.1",
+        "@motionone/types": "^10.13.0",
+        "@motionone/utils": "^10.13.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/dom": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
+      "dependencies": {
+        "@motionone/animation": "^10.12.0",
+        "@motionone/generators": "^10.12.0",
+        "@motionone/types": "^10.12.0",
+        "@motionone/utils": "^10.12.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/easing": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.13.1.tgz",
+      "integrity": "sha512-INEsInHHDHVgx0dp5qlXi1lMXBqYicgLMMSn3zfGzaIvcaEbI1Uz8BoyNV4BiclTupG7RYIh+T6BU83ZcEe74g==",
+      "dependencies": {
+        "@motionone/utils": "^10.13.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/generators": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.13.1.tgz",
+      "integrity": "sha512-+HK5u2YcNJCckTTqfOLgSVcrWv2z1dVwrSZEMVJuAh0EnWEWGDJRvMBoPc0cFf/osbkA2Rq9bH2+vP0Ex/D8uw==",
+      "dependencies": {
+        "@motionone/types": "^10.13.0",
+        "@motionone/utils": "^10.13.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/types": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.13.0.tgz",
+      "integrity": "sha512-qegk4qg8U1N9ZwAJ187BG3TkZz1k9LP/pvNtCSlqdq/PMUDKlCFG4ZnjJ481P0IOH/vIw1OzIbKIuyg0A3rk9g=="
+    },
+    "node_modules/@motionone/utils": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.13.1.tgz",
+      "integrity": "sha512-TjDPTIppaf3ofBXQv4ZzAketJgN0sclALXfZ6mfrkjJkOy83mLls9744F+6S+VKCpBmvbZcBY4PQfrfhAfeMtA==",
+      "dependencies": {
+        "@motionone/types": "^10.13.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8323,6 +8382,49 @@
         "url": "https://www.patreon.com/infusion"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "dependencies": {
+        "@motionone/dom": "10.12.0",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/framer-motion/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
+    },
+    "node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -8666,6 +8768,11 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "node_modules/history": {
       "version": "5.3.0",
@@ -13005,6 +13112,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -15913,6 +16031,15 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/styled-components": {
@@ -19592,6 +19719,64 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "@motionone/animation": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.13.1.tgz",
+      "integrity": "sha512-dxQ+1wWxL6iFHDy1uv6hhcPjIdOg36eDT56jN4LI7Z5HZRyLpq8x1t7JFQclo/IEIb+6Bk4atmyinGFdXVECuA==",
+      "requires": {
+        "@motionone/easing": "^10.13.1",
+        "@motionone/types": "^10.13.0",
+        "@motionone/utils": "^10.13.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/dom": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
+      "requires": {
+        "@motionone/animation": "^10.12.0",
+        "@motionone/generators": "^10.12.0",
+        "@motionone/types": "^10.12.0",
+        "@motionone/utils": "^10.12.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/easing": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.13.1.tgz",
+      "integrity": "sha512-INEsInHHDHVgx0dp5qlXi1lMXBqYicgLMMSn3zfGzaIvcaEbI1Uz8BoyNV4BiclTupG7RYIh+T6BU83ZcEe74g==",
+      "requires": {
+        "@motionone/utils": "^10.13.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/generators": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.13.1.tgz",
+      "integrity": "sha512-+HK5u2YcNJCckTTqfOLgSVcrWv2z1dVwrSZEMVJuAh0EnWEWGDJRvMBoPc0cFf/osbkA2Rq9bH2+vP0Ex/D8uw==",
+      "requires": {
+        "@motionone/types": "^10.13.0",
+        "@motionone/utils": "^10.13.1",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@motionone/types": {
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.13.0.tgz",
+      "integrity": "sha512-qegk4qg8U1N9ZwAJ187BG3TkZz1k9LP/pvNtCSlqdq/PMUDKlCFG4ZnjJ481P0IOH/vIw1OzIbKIuyg0A3rk9g=="
+    },
+    "@motionone/utils": {
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.13.1.tgz",
+      "integrity": "sha512-TjDPTIppaf3ofBXQv4ZzAketJgN0sclALXfZ6mfrkjJkOy83mLls9744F+6S+VKCpBmvbZcBY4PQfrfhAfeMtA==",
+      "requires": {
+        "@motionone/types": "^10.13.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -23507,6 +23692,45 @@
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
       "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
     },
+    "framer-motion": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "@motionone/dom": "10.12.0",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "optional": true,
+          "requires": {
+            "@emotion/memoize": "0.7.4"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+          "optional": true
+        }
+      }
+    },
+    "framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -23746,6 +23970,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "history": {
       "version": "5.3.0",
@@ -26868,6 +27097,17 @@
         }
       }
     },
+    "popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "requires": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -28810,6 +29050,15 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "requires": {}
+    },
+    "style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
     },
     "styled-components": {
       "version": "5.3.5",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dom-to-image": "^2.6.0",
     "eslint-plugin-prettier": "^4.2.1",
     "file-saver": "^2.0.5",
+    "framer-motion": "^6.5.1",
     "prettier": "^2.7.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/components/Animation/animate.js
+++ b/src/components/Animation/animate.js
@@ -1,0 +1,11 @@
+export const animate = {
+  initial: {
+    opacity: 0,
+  },
+  animate: {
+    opacity: 1,
+  },
+  exit: {
+    opacity: 0,
+  },
+};

--- a/src/components/ColorDetailForms/index.jsx
+++ b/src/components/ColorDetailForms/index.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from 'components/Button';
+import { useNavigate } from 'react-router-dom';
+import ResultTitle from 'components/TestResultForms/InnerComponents/ResultTitle';
+import ColorImage from 'components/TestResultForms/InnerComponents/ColorImage';
+import ColorInfo from 'components/TestResultForms/InnerComponents/ColorInfo';
+import Header from 'components/Header';
+
+const Wrapper = styled.div`
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: content-box;
+  background-color: #fffaf5;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 90%;
+  padding-top: 40px;
+  padding-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+`;
+
+const ColorDetailForms = () => {
+  let navigate = useNavigate();
+  function moveToPastPage() {
+    navigate(-1);
+  }
+  function moveToMainPage() {
+    navigate('/home');
+  }
+
+  return (
+    <>
+      <Wrapper></Wrapper>
+      <Header title="Mood Scent" />
+      <ResultTitle />
+      <ColorImage />
+      <ColorInfo />
+      <Wrapper>
+        <ButtonWrapper>
+          <Button
+            blackButton
+            shadow
+            width="100"
+            fontSize="17"
+            marginBottom="10"
+            paddingTop="10"
+            paddingBottom="10"
+            paddingLeft="25"
+            paddingRight="25"
+            onClick={moveToPastPage}
+          >
+            이전 페이지로 이동
+          </Button>
+          <Button
+            blackButton
+            shadow
+            width="100"
+            fontSize="17"
+            marginBottom="10"
+            paddingTop="10"
+            paddingBottom="10"
+            paddingLeft="25"
+            paddingRight="25"
+            onClick={moveToMainPage}
+          >
+            홈으로 이동
+          </Button>
+        </ButtonWrapper>
+      </Wrapper>
+    </>
+  );
+};
+
+export default ColorDetailForms;

--- a/src/components/NavigationBar/index.jsx
+++ b/src/components/NavigationBar/index.jsx
@@ -25,7 +25,7 @@ const NavigationBox = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: space-evenly;
-  background-color: white;
+  background-color: black;
   border-radius: 30px;
   box-shadow: 0 0 30px 1px rgba(0, 0, 0, 0.1);
 `;
@@ -52,19 +52,19 @@ const NavigationBar = () => {
     <Wrapper>
       <NavigationBox>
         <NavigationButton type="button" value="home">
-          <MdOutlineHome size="28px" />
+          <MdOutlineHome size="28px" color="white" />
         </NavigationButton>
         <NavigationButton type="button" value="test">
-          <MdOutlineBrush size="28px" />
+          <MdOutlineBrush size="28px" color="white" />
         </NavigationButton>
         <NavigationButton type="button" value="palette">
-          <MdOutlinePalette size="28px" />
+          <MdOutlinePalette size="28px" color="white" />
         </NavigationButton>
         <NavigationButton type="button" value="setting">
-          <MdOutlineScience size="28px" />
+          <MdOutlineScience size="28px" color="white" />
         </NavigationButton>
         <NavigationButton type="button" value="myPage">
-          <MdOutlineEmojiEmotions size="28px" />
+          <MdOutlineEmojiEmotions size="28px" color="white" />
         </NavigationButton>
       </NavigationBox>
     </Wrapper>

--- a/src/components/OtherColorForms/InnerComponents/ColorButton.jsx
+++ b/src/components/OtherColorForms/InnerComponents/ColorButton.jsx
@@ -1,0 +1,127 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { useParams, Link } from 'react-router-dom';
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  position: relative;
+  box-sizing: content-box;
+  bottom: 0px;
+`;
+
+const StyledLink = styled(Link)`
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+`;
+
+const ColorButtonContainer = styled.button`
+  width: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: ${(props) => props.color || 'black'};
+  border-radius: 50px 50px 0 0;
+  border: none;
+  z-index: ${(props) => props.zIndex || 0};
+  box-shadow: 0 0 30px 1px rgba(0, 0, 0, 0.1);
+  margin-top: 30px;
+  transition: 0.3s;
+
+  &:hover {
+    margin-top: 0px;
+    transition: 0.3s;
+  }
+`;
+
+const ColorTitle = styled.div`
+  margin-top: 30px;
+  margin-bottom: 80px;
+  font-size: 17px;
+  font-weight: 400;
+  font-family: 'Frank Ruhl Libre', serif;
+  color: ${(props) => props.color || 'white'};
+`;
+
+const FirstButtonGroup = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  position: absolute;
+  bottom: 70px;
+`;
+
+const SecondButtonGroup = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  position: absolute;
+  bottom: 0px;
+`;
+
+const ColorButton = () => {
+  const { color } = useParams();
+  const [firstThreeColors, setFirstThreeColors] = useState();
+  const [secondThreeColors, setSecondThreeColors] = useState();
+
+  useEffect(() => {
+    let allColor = [
+      { name: 'red', bgColor: '#F0213B', textColor: 'white', zIndex: '1' },
+      { name: 'yellow', bgColor: '#FFD700', textColor: 'white', zIndex: '2' },
+      { name: 'green', bgColor: '#339A53', textColor: 'white', zIndex: '3' },
+      { name: 'blue', bgColor: '#2878A2', textColor: 'white', zIndex: '4' },
+      { name: 'black', bgColor: 'black', textColor: 'white', zIndex: '5' },
+      { name: 'white', bgColor: 'white', textColor: 'black', zIndex: '6' },
+      { name: 'purple', bgColor: '#7B78B8', textColor: 'white', zIndex: '7' },
+    ];
+
+    let filtered = allColor.filter((element) => element.name !== color);
+
+    const storeFirstThreeColors = filtered.slice(0, 3).map((colorData) => (
+      <ColorButtonContainer
+        key={colorData.name}
+        value={colorData.name}
+        color={colorData.bgColor}
+        zIndex={colorData.zIndex}
+      >
+        <StyledLink to={`/home/color-detail/${colorData.name}`}>
+          <ColorTitle color={colorData.textColor}>
+            {colorData.name.toUpperCase()}
+          </ColorTitle>
+        </StyledLink>
+      </ColorButtonContainer>
+    ));
+
+    const storeSecondThreeColors = filtered.slice(3, 7).map((colorData) => (
+      <ColorButtonContainer
+        key={colorData.name}
+        value={colorData.name}
+        color={colorData.bgColor}
+        zIndex={colorData.zIndex}
+      >
+        <StyledLink to={`/home/color-detail/${colorData.name}`}>
+          <ColorTitle color={colorData.textColor}>
+            {colorData.name.toUpperCase()}
+          </ColorTitle>
+        </StyledLink>
+      </ColorButtonContainer>
+    ));
+
+    setFirstThreeColors(storeFirstThreeColors);
+    setSecondThreeColors(storeSecondThreeColors);
+  }, []);
+
+  return (
+    <>
+      <Wrapper>
+        <FirstButtonGroup>{firstThreeColors}</FirstButtonGroup>
+        <SecondButtonGroup>{secondThreeColors}</SecondButtonGroup>
+      </Wrapper>
+    </>
+  );
+};
+
+export default ColorButton;

--- a/src/components/OtherColorForms/index.jsx
+++ b/src/components/OtherColorForms/index.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import styled from 'styled-components';
+import ColorButton from './InnerComponents/ColorButton';
+
+const Wrapper = styled.div`
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: content-box;
+  margin-top: 30px;
+`;
+
+const ColorContainer = styled.div`
+  width: 85%;
+  height: 50vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+  align-items: center;
+  text-align: center;
+  border: 1px solid black;
+`;
+
+const MainTitle = styled.div`
+  font-size: 50px;
+  font-weight: 900;
+  font-family: 'Frank Ruhl Libre', serif;
+  text-align: center;
+  line-height: 1.3;
+  color: black;
+  position: absolute;
+  top: 180px;
+`;
+
+const ButtonContainer = styled.div`
+  width: 100%;
+`;
+
+const SubTitle = styled.div`
+  margin-top: 30px;
+  font-size: 15px;
+  font-weight: 600;
+  font-family: 'Frank Ruhl Libre', serif;
+  line-height: 1.3;
+  text-align: center;
+  color: black;
+`;
+
+const OtherColorForms = () => {
+  return (
+    <>
+      <Wrapper>
+        <MainTitle>
+          OTHER
+          <br /> COLORS
+        </MainTitle>
+        <ColorContainer>
+          <ButtonContainer>
+            <ColorButton />
+          </ButtonContainer>
+        </ColorContainer>
+        <SubTitle>
+          carefully curated colors
+          <br /> and the way they affect our mood
+        </SubTitle>
+      </Wrapper>
+    </>
+  );
+};
+
+export default OtherColorForms;

--- a/src/components/TestResultForms/InnerComponents/ResultETC.jsx
+++ b/src/components/TestResultForms/InnerComponents/ResultETC.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Button from 'components/Button';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const Wrapper = styled.div`
   width: 100vw;
@@ -66,9 +66,15 @@ const ReviewButtonWrapper = styled.div`
 `;
 
 const ResultETC = () => {
+  const { color } = useParams('color');
   let navigate = useNavigate();
+
   function moveToTestPage() {
     navigate('/home/scent-test');
+  }
+
+  function moveToOtherColorPage() {
+    navigate(`/home/other-color/except/${color}`);
   }
 
   return (
@@ -107,8 +113,9 @@ const ResultETC = () => {
             paddingBottom="10"
             paddingLeft="25"
             paddingRight="25"
+            onClick={moveToOtherColorPage}
           >
-            모든 결과 유형 보기
+            다른 결과 유형 보기
           </Button>
           <Button
             blackButton

--- a/src/pages/ColorDetail/index.jsx
+++ b/src/pages/ColorDetail/index.jsx
@@ -2,19 +2,19 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { animate } from 'components/Animation/animate';
 import HeaderSticky from 'components/HeaderSticky';
-import TestResultForms from 'components/TestResultForms';
+import ColorDetailForms from 'components/ColorDetailForms';
 
-const TestResult = () => {
+const ColorDetail = () => {
   return (
     <motion.div
       initial={animate.initial}
       animate={animate.animate}
       exit={animate.exit}
     >
-      <HeaderSticky title="Per/scent" />
-      <TestResultForms />
+      <HeaderSticky title="Mood Palette" />
+      <ColorDetailForms />
     </motion.div>
   );
 };
 
-export default TestResult;
+export default ColorDetail;

--- a/src/pages/Landing/index.jsx
+++ b/src/pages/Landing/index.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import { motion } from 'framer-motion';
+import { animate } from 'components/Animation/animate';
 import SimpleSlider from 'components/LandingCarousel';
 import Button from 'components/Button';
 
@@ -22,7 +24,11 @@ const ButtonContainer = styled.div`
 
 const Landing = () => {
   return (
-    <>
+    <motion.div
+      initial={animate.initial}
+      animate={animate.animate}
+      exit={animate.exit}
+    >
       <Wrapper>
         <SimpleSlider />
         <ButtonContainer>
@@ -50,7 +56,7 @@ const Landing = () => {
           </Button>
         </ButtonContainer>
       </Wrapper>
-    </>
+    </motion.div>
   );
 };
 

--- a/src/pages/OtherColor/index.jsx
+++ b/src/pages/OtherColor/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { animate } from 'components/Animation/animate';
+import Header from 'components/Header';
+import NavigationBar from 'components/NavigationBar';
+import OtherColorForms from 'components/OtherColorForms';
+
+const OtherColor = () => {
+  return (
+    <motion.div
+      initial={animate.initial}
+      animate={animate.animate}
+      exit={animate.exit}
+    >
+      <Header title="Mood Palette" />
+      <OtherColorForms />
+      <NavigationBar />
+    </motion.div>
+  );
+};
+
+export default OtherColor;

--- a/src/pages/ScentTest/index.jsx
+++ b/src/pages/ScentTest/index.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { motion } from 'framer-motion';
+import { animate } from 'components/Animation/animate';
 import { MdArrowBack, MdArrowForward } from 'react-icons/md';
 import Header from 'components/Header';
 import TestForms from 'components/TestForms';
@@ -48,7 +50,11 @@ const ScentTest = () => {
   };
 
   return (
-    <>
+    <motion.div
+      initial={animate.initial}
+      animate={animate.animate}
+      exit={animate.exit}
+    >
       <Header title="Per/scent" />
       <TestForms step={step} />
       <Wrapper>
@@ -63,7 +69,7 @@ const ScentTest = () => {
         </BarBox>
       </Wrapper>
       <NavigationBar />
-    </>
+    </motion.div>
   );
 };
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,9 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
 import Landing from './../pages/Landing/index';
 import Main from '../pages/Main';
+import OtherColor from 'pages/OtherColor';
+import ColorDetail from 'pages/ColorDetail';
 import ScentTest from 'pages/ScentTest';
 import TestResult from 'pages/TestResult';
 
@@ -8,12 +11,19 @@ import TestResult from 'pages/TestResult';
 
 const Router = () => (
   <BrowserRouter>
-    <Routes>
-      <Route path="/" element={<Landing />} />
-      <Route path="/home" element={<Main />} />
-      <Route path="/home/scent-test" element={<ScentTest />} />
-      <Route path="/home/scent-test/result/:color" element={<TestResult />} />
-    </Routes>
+    <AnimatePresence>
+      <Routes>
+        <Route path="/" element={<Landing />} />
+        <Route path="/home" element={<Main />} />
+        <Route
+          path="/home/other-color/except/:color"
+          element={<OtherColor />}
+        />
+        <Route path="/home/color-detail/:color" element={<ColorDetail />} />
+        <Route path="/home/scent-test" element={<ScentTest />} />
+        <Route path="/home/scent-test/result/:color" element={<TestResult />} />
+      </Routes>
+    </AnimatePresence>
   </BrowserRouter>
 );
 


### PR DESCRIPTION
## PR 내용
### Other Color Page 추가
테스트 결과 페이지에서 버튼을 누르면, 해당 테스트 결과 컬러를 제외한 나머지 컬러들에 대한 정보를 확인할 수 있는 Other Color Page를 작성하였습니다. `/home/other-color/except/:color`가 주소이며, `:color` 위치에 해당하는 컬러를 제외하고 나머지 6가지 컬러를 보여줍니다. hover 시에 해당 버튼이 늘어나는 애니메이션을 추가하였지만, 모바일 뷰에서는 확인이 불가능합니다.

### Color Detail Page 추가
Test Result Page의 Component들을 이용하여 Detail Page를 작성하였습니다. `/home/color-detail/:color` 로 이동하며, `:color`에 해당하는 컬러 정보를 보여줍니다. 하단에는 이전으로 이동하기와 홈으로 이동하기 버튼을 만들어 페이지간 이동을 편하게 하였습니다.

### 페이지 전환 애니메이션 추가
`framer-motion` 을 install하여 구현하였습니다. 이후 다른 Page들에 대한 페이지 전환 애니메이션은 아래와 같이 작성해주시면 됩니다.

```Javascript
import { motion } from 'framer-motion';
import { animate } from 'components/Animation/animate';
// 위 2개 import하기

const 페이지이름 = () => {
  return (
    <motion.div
      initial={animate.initial}
      animate={animate.animate}
      exit={animate.exit}
    >
      안에 담길 Component들
    </motion.div>
  );
};

// 겉을 위와 같은 `motion.div`으로 감싸줍니다.
```

## 완성품 영상
https://user-images.githubusercontent.com/79556112/180844555-c2d36536-25b6-4887-af39-db7295873e89.mp4

## 링크
Trello: 